### PR TITLE
Implement reformulation as MOI layer

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,0 +1,14 @@
+name = "GraphsOfConvexSets"
+uuid = "823ad9d2-5d47-4587-a0bc-029103bd504c"
+version = "0.1.0"
+
+[deps]
+Graphs = "86223c79-3864-5bf0-83f7-82e725a168b6"
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+MathOptInterface = "b8f27783-ece8-5eb3-8dc8-9495eed66fee"
+
+[compat]
+Graphs = "1"
+LinearAlgebra = "1.10"
+MathOptInterface = "1.42.0"
+julia = "1.10"

--- a/examples/Project.toml
+++ b/examples/Project.toml
@@ -1,0 +1,6 @@
+[deps]
+GraphsOfConvexSets = "823ad9d2-5d47-4587-a0bc-029103bd504c"
+HiGHS = "87dc4568-4c63-4d18-b0c0-bb2238e4078b"
+Hypatia = "b99e6be6-89ff-11e8-14f8-45c827f4f8f2"
+JuMP = "4076af6c-e467-56ae-b986-b466b2749572"
+Pajarito = "2f354839-79df-5901-9f0a-cdb2aac6fe30"

--- a/examples/shortest_path.jl
+++ b/examples/shortest_path.jl
@@ -1,0 +1,65 @@
+# Inspired from `gcspy/examples/shortest_path.py`
+
+using JuMP
+import Pajarito, HiGHS, Hypatia
+using LinearAlgebra
+using GraphsOfConvexSets
+
+model = Model(() -> Optimizer(
+    optimizer_with_attributes(
+        Pajarito.Optimizer,
+        "oa_solver" => optimizer_with_attributes(
+            HiGHS.Optimizer,
+            MOI.Silent() => false,
+            "mip_feasibility_tolerance" => 1e-8,
+            "mip_rel_gap" => 1e-6,
+        ),
+        "conic_solver" =>
+            optimizer_with_attributes(Hypatia.Optimizer, MOI.Silent() => false),
+    )
+))
+
+# source vertex
+x = @variable(model, [1:2])
+MOI.set.(model, VariableVertex(), x, 1)
+c = [1, 0] # center of the set
+D = Diagonal([1, 1/2]) # scaling matrix
+con_ref = @constraint(model, [1; D * (x - c)] in SecondOrderCone())
+MOI.set(model, VertexOrEdge(), con_ref, 1)
+
+# target vertex
+x = @variable(model, [1:2])
+MOI.set.(model, VariableVertex(), x, 2)
+c = [10, 0] # center of the set
+D = Diagonal([1/2, 1]) # scaling matrix
+con_ref = @constraint(model, [1; D * (x - c)] in SecondOrderCone())
+MOI.set(model, VertexOrEdge(), con_ref, 2)
+con_ref = @constraint(model, x[1] <= c[1]) # cut right half of the set
+MOI.set(model, VertexOrEdge(), con_ref, 2)
+
+# vertex 1
+x = @variable(model, [1:2])
+MOI.set.(model, VariableVertex(), x, 3)
+c = [4, 2] # center of the set
+con_ref = @constraint(model, [1; x - c] in MOI.NormInfinityCone(3))
+MOI.set(model, VertexOrEdge(), con_ref, 3)
+
+# vertex 2
+x = @variable(model, [1:2])
+MOI.set.(model, VariableVertex(), x, 4)
+c = [5.5, -2] # center of the set
+con_ref = @constraint(model, [1.2; x - c] in MOI.NormOneCone(3))
+MOI.set(model, VertexOrEdge(), con_ref, 4)
+con_ref = @constraint(model, [1; x - c] in MOI.NormOneCone(3))
+MOI.set(model, VertexOrEdge(), con_ref, 4)
+
+# vertex 3
+x = @variable(model, [1:2])
+MOI.set.(model, VariableVertex(), x, 5)
+c = [7, 2] # center of the set
+con_ref = @constraint(model, [1; x - c] in SecondOrderCone())
+MOI.set(model, VertexOrEdge(), con_ref, 5)
+
+MOI.set(model, Problem(), ShortestPathProblem(1, 2))
+
+optimize!(model)

--- a/src/GraphsOfConvexSets.jl
+++ b/src/GraphsOfConvexSets.jl
@@ -1,0 +1,24 @@
+module GraphsOfConvexSets
+
+include("MOI_wrapper.jl")
+
+# Taken from JuMP.jl, exports all symbols not starting with `_`
+const _EXCLUDE_SYMBOLS = [Symbol(@__MODULE__), :eval, :include]
+
+for sym in names(@__MODULE__; all = true)
+    sym_string = string(sym)
+    if sym in _EXCLUDE_SYMBOLS ||
+       startswith(sym_string, "_") ||
+       startswith(sym_string, "@_")
+        continue
+    end
+    if !(
+        Base.isidentifier(sym) ||
+        (startswith(sym_string, "@") && Base.isidentifier(sym_string[2:end]))
+    )
+        continue
+    end
+    @eval export $sym
+end
+
+end

--- a/src/MOI_wrapper.jl
+++ b/src/MOI_wrapper.jl
@@ -1,0 +1,260 @@
+import Graphs
+import MathOptInterface as MOI
+using LinearAlgebra
+
+const VertexOrEdgeType = Union{Int,Graphs.Edge{Int}}
+
+struct Problem <: MOI.AbstractModelAttribute end
+struct VariableVertex <: MOI.AbstractVariableAttribute end
+struct VertexOrEdge <: MOI.AbstractConstraintAttribute end
+
+mutable struct Optimizer{O} <: MOI.AbstractOptimizer
+    inner::O
+    graph::Union{Nothing,Graphs.SimpleDiGraph{Int}}
+    variable_vertex::Union{Nothing,Vector{Int}}
+    x::Union{Nothing,Vector{MOI.VariableIndex}}
+    y::Dict{VertexOrEdgeType,MOI.VariableIndex}
+    z::Dict{Tuple{MOI.VariableIndex,MOI.VariableIndex},MOI.VariableIndex} # (x, y) -> z
+    #vertex_or_edge::Dict{MOI.ConstraintIndex,VertexOrEdgeType}
+    function Optimizer(optimizer_constructor)
+        inner = MOI.instantiate(optimizer_constructor, with_bridge_type=Float64)
+        return new{typeof(inner)}(
+            inner,
+            nothing,
+            nothing,
+            nothing,
+            Dict{VertexOrEdgeType,MOI.VariableIndex}(),
+            Dict{Tuple{MOI.VariableIndex,MOI.VariableIndex},MOI.VariableIndex}(),
+            #Dict{MOI.ConstraintIndex,VertexOrEdgeType}(),
+        )
+    end
+end
+
+MOI.is_empty(model::Optimizer) = MOI.is_empty(model.inner)
+function MOI.empty!(model::Optimizer)
+    MOI.empty!(model.inner)
+    model.graph = nothing
+    model.variable_vertex = nothing
+    model.x = nothing
+    empty!(model.y)
+    empty!(model.z)
+    #empty!(model.vertex_or_edge)
+    return
+end
+MOI.optimize!(model::Optimizer) = MOI.optimize!(model.inner)
+function MOI.supports(model::Optimizer, attr::MOI.AnyAttribute)
+    return MOI.supports(model.inner, attr)
+end
+function MOI.supports_constraint(model::Optimizer, F::Type{<:MOI.AbstractFunction}, S::Type{<:MOI.AbstractSet})
+    return MOI.supports_constraint(model.inner, F, S)
+end
+
+#function _homogenize(model::Optimizer, constant::Number, vertex_or_edge)
+#    key = vertex_or_edge
+#    if haskey(model.y, key)
+#        # The constrant index is also returned but we don't need it.
+#        # We can construct it like this if needed:
+#        # `MOI.ConstraintIndex{MOI.VariableIndex,MOI.ZeroOne}(model.z[key].value)`
+#        model.y[key], _ = MOI.add_constrained_variable(model, MOI.ZeroOne())
+#    end
+#    return MOI.ScalarAffineTerm(constant, model.y[key])
+#end
+#
+#function _homogenize(model::Optimizer, constants::Vector, vertex_or_edge)
+#    return MOI.VectorAffineTerm.(eachindex(constants), _homogenize.(model, constants, vertex_or_edge))
+#end
+#
+#function _homogenize(model::Optimizer, vi::MOI.VariableIndex, vertex_or_edge)
+#    key = (vertex_or_edge, vi)
+#    if haskey(model.z, key)
+#        # The constrant index is also returned but we don't need it.
+#        # We can construct it like this if needed:
+#        # `MOI.ConstraintIndex{MOI.VariableIndex,MOI.ZeroOne}(model.z[key].value)`
+#        model.z[key] = MOI.add_variable(model)
+#    end
+#    return model.z[key]
+#end
+#
+#function _homogenize(model::Optimizer, term::MOI.ScalarAffineTerm, vertex_or_edge)
+#    return MOI.ScalarAffineTerm(
+#        term.coefficient,
+#        _homogenize(model, term.variable, vertex_or_edge),
+#    )
+#end
+
+function _mult_subs(model, xterm::MOI.ScalarAffineTerm, ineq::MOI.ScalarAffineFunction)
+    result = (xterm.coefficient * ineq.constant) * xterm.variable
+    for yterm in ineq.terms
+        push!(result.terms, MOI.ScalarAffineTerm(
+            xterm.coefficient * yterm.coefficient,
+            model.z[(xterm.variable, yterm.variable)],
+        ))
+    end
+    return result
+end
+
+function _mult_subs(model, term::MOI.ScalarAffineTerm, ineq::MOI.VariableIndex)
+    return term.coefficient * model.z[(term.variable, ineq)]
+end
+
+# Return the result of `affine * ineq` after substituting the bilinear terms `x * y` into `z`
+function _mult_subs(model::Optimizer, affine::MOI.ScalarAffineFunction{T}, ineq) where {T}
+    result = zero(MOI.ScalarAffineFunction{T})
+    for term in affine.terms
+        scalar = _mult_subs(model, term, ineq)
+        MOI.Utilities.operate!(+, T, result, scalar)
+    end
+    MOI.Utilities.operate!(+, T, result, affine.constant * ineq)
+    return result
+end
+
+function _mult_subs(model::Optimizer, affine::MOI.VectorAffineFunction{T}, ineq) where {T}
+    result = MOI.Utilities.zero_with_output_dimension(MOI.VectorAffineFunction{T}, MOI.output_dimension(affine))
+    for term in affine.terms
+        scalar = _mult_subs(model, term.scalar_term, ineq)
+        MOI.Utilities.operate_output_index!(+, T, term.output_index, result, scalar)
+    end
+    for i in eachindex(affine.constants)
+        α = affine.constants[i]
+        MOI.Utilities.operate_output_index!(+, T, i, result, α * ineq)
+    end
+    return result
+end
+
+function _build_graph(graph::Graphs.DiGraph, src::MOI.ModelLike, ::Type{F}, ::Type{S}) where {F,S}
+    for ci in MOI.get(src, MOI.ListOfConstraintIndices{F,S}())
+        vertex_or_edge = MOI.get(src, VertexOrEdge(), ci)
+        if vertex_or_edge isa Tuple{Int,Int} # It's an edge
+            u, v = vertex_or_edge
+            Graphs.add_edge!(graph, u, v)
+        end
+    end
+end
+
+# Function barrier to work around the type instability when getting `F` and `S`
+function _add_constraints(dest::Optimizer, src::MOI.ModelLike, ::Type{F}, ::Type{S}) where {F,S}
+    for ci in MOI.get(src, MOI.ListOfConstraintIndices{F,S}())
+        func = MOI.get(src, MOI.ConstraintFunction(), ci)
+        set = MOI.get(src, MOI.ConstraintSet(), ci)
+        @assert !(set isa MOI.Interval) # TODO exclude with `supports_constraint`
+        if MOI.Utilities.supports_shift_constant(typeof(set))
+            # We need to move the constant to the set to homogenize it
+            constant = MOI.constant(set)
+            func -= constant
+            set = MOI.Utilities.shift_constant(set, -constant)
+        end
+        vertex_or_edge = MOI.get(src, VertexOrEdge(), ci)
+        # left of (5.8c) or (5.8e)
+        linear = _mult_subs(dest, func, dest.y[vertex_or_edge])
+        _add_constraint(dest.inner, linear, set)
+        if vertex_or_edge isa Int
+            # It is a vertex so we can use Lemma 5.1 of the thesis
+            # right of (5.8c)
+            v = vertex_or_edge
+            linear = _mult_subs(dest, func, 1.0 - dest.y[v])
+            _add_constraint(dest.inner, linear, set)
+            # (5.8d)
+            for u in Graphs.inneighbors(dest.graph, v)
+                linear = _mult_subs(dest, func, dest.y[(u, v)])
+                _add_constraint(dest.inner, linear, set)
+            end
+            for u in Graphs.outneighbors(dest.graph, v)
+                linear = _mult_subs(dest, func, 1.0 - dest.y[(v, u)])
+                _add_constraint(dest.inner, linear, set)
+            end
+        end
+    end
+end
+
+# We need to put the constant back in the set when appropriate
+_add_constraint(model, f::MOI.AbstractScalarFunction, s) = MOI.Utilities.normalize_and_add_constraint(model, f, s)
+_add_constraint(model, f::MOI.AbstractVectorFunction, s) = MOI.add_constraint(model, f, s)
+
+struct ShortestPathProblem
+    source::Int
+    target::Int
+end
+
+MOI.Utilities.map_indices(::Function, p::ShortestPathProblem) = p
+
+function _constrain_admissible_subgraphs(model::Optimizer, spp::ShortestPathProblem)
+    for v in Graphs.vertices(model.graph)
+        y = model.y[v]
+        inv = MOI.VariableIndex[model.y[(u, v)] for u in Graphs.inneighbors(model.graph, v)]
+        MOI.add_constraint(
+            model.inner,
+            y - dot(ones(length(inv)), inv),
+            MOI.EqualTo(float(v == spp.source)),
+        )
+        outv = MOI.VariableIndex[model.y[(v, u)] for u in Graphs.outneighbors(model.graph, v)]
+        MOI.add_constraint(
+            model.inner,
+            y - dot(ones(length(outv)), outv),
+            MOI.EqualTo(float(v == spp.target)),
+        )
+    end
+    for i in eachindex(model.x)
+        x = model.x[i]
+        v = model.variable_vertex[i]
+        z = model.z[(x, model.y[v])]
+        inv = MOI.VariableIndex[model.z[(x, model.y[Graphs.Edge(u, v)])] for u in Graphs.inneighbors(model.graph, v)]
+        MOI.add_constraint(
+            model.inner,
+            z - dot(ones(length(inv)), inv) - float(v == spp.source) * x,
+            MOI.EqualTo(0.0),
+        )
+        outv = MOI.VariableIndex[model.z[(x, model.y[Graphs.Edge(v, u)])] for u in Graphs.outneighbors(model.graph, v)]
+        MOI.add_constraint(
+            model.inner,
+            z - dot(ones(length(outv)), outv) - float(v == spp.target) * x,
+            MOI.EqualTo(0.0),
+        )
+    end
+end
+
+function MOI.copy_to(dest::Optimizer, src::MOI.ModelLike)
+    MOI.empty!(dest)
+    vis = MOI.get(src, MOI.ListOfVariableIndices())
+    dest.x = MOI.add_variables(dest.inner, length(vis))
+    index_map = MOI.Utilities.IndexMap()
+    for i in eachindex(vis)
+        index_map[vis[i]] = dest.x[i]
+    end
+    dest.variable_vertex = MOI.get.(src, VariableVertex(), vis)
+    vertices = unique!(sort(dest.variable_vertex))
+    @assert vertices[1] == 1
+    @assert vertices[end] == length(vertices)
+    dest.graph = Graphs.DiGraph(length(vertices))
+    # We build the graph first so that we have all the constraints to be able to do (5.8d)
+    # That also allows to create all `y` and `z` variables
+    for (F, S) in MOI.get(src, MOI.ListOfConstraintTypesPresent())
+        _build_graph(dest.graph, src, F, S)
+    end
+    # Create `y` variables
+    for vertex in Graphs.vertices(dest.graph)
+        # The constrant index is also returned but we don't need it.
+        # We can construct it like this if needed:
+        # `MOI.ConstraintIndex{MOI.VariableIndex,MOI.ZeroOne}(model.z[key].value)`
+        dest.y[vertex], _ = MOI.add_constrained_variable(dest.inner, MOI.ZeroOne())
+    end
+    for edge in Graphs.edges(dest.graph)
+        dest.y[edge], _ = MOI.add_constrained_variable(dest.inner, MOI.ZeroOne())
+    end
+    # Create `z` variables
+    for i in eachindex(dest.x)
+        x = dest.x[i]
+        v = dest.variable_vertex[i]
+        dest.z[(x, dest.y[v])] = MOI.add_variable(dest.inner)
+        for u in Graphs.inneighbors(dest.graph, v)
+            dest.z[(x, dest.y[Graphs.edge(u, v)])] = MOI.add_variable(dest.inner)
+        end
+        for u in Graphs.outneighbors(dest.graph, v)
+            dest.z[(x, dest.y[Graphs.edge(v, u)])] = MOI.add_variable(dest.inner)
+        end
+    end
+    for (F, S) in MOI.get(src, MOI.ListOfConstraintTypesPresent())
+        _add_constraints(dest, src, F, S)
+    end
+    _constrain_admissible_subgraphs(dest, MOI.get(src, Problem()))
+    return index_map
+end


### PR DESCRIPTION
Proof-of-concept implementation of MathOptInterface (MOI) layer implementing the Graph of convex sets approach.

- [ ] Add objective function
- [ ] Debug it to make sure it works

At the moment, there is no JuMP interface so you need to manually set the vertices or edges to the variables and constraints after creating them which is a bit less readable and error-prone.
A nicer interface like
```julia
v = Vertex(model, 1)
@variable(v, x[1:2])
@constraint(v, sum(x) <= 1)
```
would be possible with something like (untested):
```julia
struct Vertex{M<:JuMP.AbstractModel} <: JuMP.AbstractModel
    model::M
    vertex::Int
end
function JuMP.add_variable(v::Vertex, var, name)
    var_ref = JuMP.add_variable(v.model, var, name)
    MOI.set(v.model, VariableVertex(), var_ref, v.vertex)
end
function JuMP.add_constraint(v::Vertex, con, name)
    con_ref = JuMP.add_constraint(v.model, con, name)
    MOI.set(v.model, VertexOrEdge(), con_ref, v.vertex)
end
```