### PR TITLE
Finish shortest path example

### DIFF
--- a/examples/Project.toml
+++ b/examples/Project.toml
@@ -1,6 +1,8 @@
 [deps]
+Graphs = "86223c79-3864-5bf0-83f7-82e725a168b6"
 GraphsOfConvexSets = "823ad9d2-5d47-4587-a0bc-029103bd504c"
 HiGHS = "87dc4568-4c63-4d18-b0c0-bb2238e4078b"
 Hypatia = "b99e6be6-89ff-11e8-14f8-45c827f4f8f2"
 JuMP = "4076af6c-e467-56ae-b986-b466b2749572"
 Pajarito = "2f354839-79df-5901-9f0a-cdb2aac6fe30"
+Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"

--- a/examples/shortest_path.jl
+++ b/examples/shortest_path.jl
@@ -1,4 +1,4 @@
-# Inspired from `gcspy/examples/shortest_path.py`
+# Inspired from https://github.com/TobiaMarcucci/gcspy/blob/main/examples/shortest_path/shortest_path.py
 
 using JuMP
 import Pajarito, HiGHS, Hypatia
@@ -19,47 +19,102 @@ model = Model(() -> Optimizer(
     )
 ))
 
+@variable(model, x[1:5, 1:2])
+MOI.set.(model, VariableVertex(), x, 1:5)
+
+# Centers
+C = [
+     1    0
+    10    0
+     4    2
+     5.5 -2
+     7    2
+]
+
 # source vertex
-x = @variable(model, [1:2])
-MOI.set.(model, VariableVertex(), x, 1)
-c = [1, 0] # center of the set
 D = Diagonal([1, 1/2]) # scaling matrix
-con_ref = @constraint(model, [1; D * (x - c)] in SecondOrderCone())
+con_ref = @constraint(model, [1; D * (x[1, :] - C[1, :])] in SecondOrderCone())
 MOI.set(model, VertexOrEdge(), con_ref, 1)
 
 # target vertex
-x = @variable(model, [1:2])
-MOI.set.(model, VariableVertex(), x, 2)
-c = [10, 0] # center of the set
 D = Diagonal([1/2, 1]) # scaling matrix
-con_ref = @constraint(model, [1; D * (x - c)] in SecondOrderCone())
+con_ref = @constraint(model, [1; D * (x[2, :] - C[2, :])] in SecondOrderCone())
 MOI.set(model, VertexOrEdge(), con_ref, 2)
-con_ref = @constraint(model, x[1] <= c[1]) # cut right half of the set
+con_ref = @constraint(model, x[2, 1] <= C[2, 1]) # cut right half of the set
 MOI.set(model, VertexOrEdge(), con_ref, 2)
 
 # vertex 1
-x = @variable(model, [1:2])
-MOI.set.(model, VariableVertex(), x, 3)
-c = [4, 2] # center of the set
-con_ref = @constraint(model, [1; x - c] in MOI.NormInfinityCone(3))
+con_ref = @constraint(model, [1; x[3, :] - C[3, :]] in MOI.NormInfinityCone(3))
 MOI.set(model, VertexOrEdge(), con_ref, 3)
 
 # vertex 2
-x = @variable(model, [1:2])
-MOI.set.(model, VariableVertex(), x, 4)
-c = [5.5, -2] # center of the set
-con_ref = @constraint(model, [1.2; x - c] in MOI.NormOneCone(3))
+con_ref = @constraint(model, [1.2; x[4, :] - C[4, :]] in MOI.NormOneCone(3))
 MOI.set(model, VertexOrEdge(), con_ref, 4)
-con_ref = @constraint(model, [1; x - c] in MOI.NormOneCone(3))
+con_ref = @constraint(model, [1; x[4, :] - C[4, :]] in SecondOrderCone())
 MOI.set(model, VertexOrEdge(), con_ref, 4)
 
 # vertex 3
-x = @variable(model, [1:2])
-MOI.set.(model, VariableVertex(), x, 5)
-c = [7, 2] # center of the set
-con_ref = @constraint(model, [1; x - c] in SecondOrderCone())
+con_ref = @constraint(model, [1; x[5, :] - C[5, :]] in SecondOrderCone())
 MOI.set(model, VertexOrEdge(), con_ref, 5)
+
+costs = VariableRef[]
+
+edges = [(1, 3), (1, 4), (3, 4), (3, 5), (4, 5), (4, 2), (5, 2)]
+
+for (src, dst) in edges
+    cost = @variable(model)
+    push!(costs, cost)
+    # We want the bound constraint to be valid even if the vertex is unused so
+    # we add it as a vertex constraint as these are enforced when they are vertex constraint.
+    # Indeed, the sum of (5.7a) and (5.7b) is (x_v, 1) in X_v.
+    MOI.set(model, VariableVertex(), cost, src)
+    cons_ref = @constraint(model, cost >= 0)
+    MOI.set(model, VertexOrEdge(), cons_ref, src)
+
+    cons_ref = @constraint(model, [cost; x[dst, :] - x[src, :]] in SecondOrderCone())
+    MOI.set(model, VertexOrEdge(), cons_ref, (src, dst))
+
+    cons_ref = @constraint(model, x[src, 2] <= x[dst, 2])
+    MOI.set(model, VertexOrEdge(), cons_ref, (src, dst))
+end
+
+@objective(model, Min, sum(costs))
 
 MOI.set(model, Problem(), ShortestPathProblem(1, 2))
 
 optimize!(model)
+
+sol = MOI.get(model, GraphsOfConvexSets.SubGraph())
+
+using GraphPlot
+gplot(sol, nodelabel = 1:5, layout = shell_layout)
+
+xv = value.(x)
+
+using Plots
+p = plot()
+
+using Graphs
+for (edge, cost) in zip(edges, value.(costs))
+    if Graphs.has_edge(sol, edge)
+        v = [edge...]
+        plot!(p, xv[v, 1], xv[v, 2], arrow = true, label = "", color = :grey, linewidth=2)
+        dist = norm(xv[v[1], :] - xv[v[2], :])
+        if !isapprox(dist, cost)
+            @warn("Cost $cost does not match the distance $dist for edge $edge")
+        end
+    elseif cost < -1e-5
+        @warn("Cost $cost of edge $edge is negative")
+    elseif cost > 1e-5
+        @warn("Cost $cost of edge $edge is positive even though the edge is not selected")
+    end
+end
+
+scatter!(p, [C[:, 1]], [C[:, 2]], label = "", markerstrokewidth = 0, markersize = 3)
+
+for i in 1:5
+    plot!(p, [C[i, 1], xv[i, 1]], [C[i, 2], xv[i, 2]], label = "", linestyle = :dash, color = :lightgrey)
+    scatter!(p, [xv[i, 1]], [xv[i, 2]], label = "$i", markerstrokewidth=0)
+end
+
+p

--- a/src/GraphsOfConvexSets.jl
+++ b/src/GraphsOfConvexSets.jl
@@ -1,6 +1,7 @@
 module GraphsOfConvexSets
 
 include("MOI_wrapper.jl")
+include("bridges.jl")
 
 # Taken from JuMP.jl, exports all symbols not starting with `_`
 const _EXCLUDE_SYMBOLS = [Symbol(@__MODULE__), :eval, :include]

--- a/src/MOI_wrapper.jl
+++ b/src/MOI_wrapper.jl
@@ -11,17 +11,16 @@ struct VertexOrEdge <: MOI.AbstractConstraintAttribute end
 mutable struct Optimizer{O} <: MOI.AbstractOptimizer
     inner::O
     graph::Union{Nothing,Graphs.SimpleDiGraph{Int}}
-    variable_vertex::Union{Nothing,Vector{Int}}
+    variable_vertex::Dict{MOI.VariableIndex,Int} # x -> vertex
     x::Union{Nothing,Vector{MOI.VariableIndex}}
     y::Dict{VertexOrEdgeType,MOI.VariableIndex}
     z::Dict{Tuple{MOI.VariableIndex,MOI.VariableIndex},MOI.VariableIndex} # (x, y) -> z
-    #vertex_or_edge::Dict{MOI.ConstraintIndex,VertexOrEdgeType}
     function Optimizer(optimizer_constructor)
         inner = MOI.instantiate(optimizer_constructor, with_bridge_type=Float64)
         return new{typeof(inner)}(
             inner,
             nothing,
-            nothing,
+            Dict{MOI.VariableIndex,Int}(),
             nothing,
             Dict{VertexOrEdgeType,MOI.VariableIndex}(),
             Dict{Tuple{MOI.VariableIndex,MOI.VariableIndex},MOI.VariableIndex}(),
@@ -34,53 +33,19 @@ MOI.is_empty(model::Optimizer) = MOI.is_empty(model.inner)
 function MOI.empty!(model::Optimizer)
     MOI.empty!(model.inner)
     model.graph = nothing
-    model.variable_vertex = nothing
+    empty!(model.variable_vertex)
     model.x = nothing
     empty!(model.y)
     empty!(model.z)
-    #empty!(model.vertex_or_edge)
     return
 end
 MOI.optimize!(model::Optimizer) = MOI.optimize!(model.inner)
 function MOI.supports(model::Optimizer, attr::MOI.AnyAttribute)
     return MOI.supports(model.inner, attr)
 end
-function MOI.supports_constraint(model::Optimizer, F::Type{<:MOI.AbstractFunction}, S::Type{<:MOI.AbstractSet})
+function MOI.supports_constraint(model::Optimizer, F::Type{<:MOI.VectorAffineFunction}, S::Type{<:MOI.AbstractVectorSet})
     return MOI.supports_constraint(model.inner, F, S)
 end
-
-#function _homogenize(model::Optimizer, constant::Number, vertex_or_edge)
-#    key = vertex_or_edge
-#    if haskey(model.y, key)
-#        # The constrant index is also returned but we don't need it.
-#        # We can construct it like this if needed:
-#        # `MOI.ConstraintIndex{MOI.VariableIndex,MOI.ZeroOne}(model.z[key].value)`
-#        model.y[key], _ = MOI.add_constrained_variable(model, MOI.ZeroOne())
-#    end
-#    return MOI.ScalarAffineTerm(constant, model.y[key])
-#end
-#
-#function _homogenize(model::Optimizer, constants::Vector, vertex_or_edge)
-#    return MOI.VectorAffineTerm.(eachindex(constants), _homogenize.(model, constants, vertex_or_edge))
-#end
-#
-#function _homogenize(model::Optimizer, vi::MOI.VariableIndex, vertex_or_edge)
-#    key = (vertex_or_edge, vi)
-#    if haskey(model.z, key)
-#        # The constrant index is also returned but we don't need it.
-#        # We can construct it like this if needed:
-#        # `MOI.ConstraintIndex{MOI.VariableIndex,MOI.ZeroOne}(model.z[key].value)`
-#        model.z[key] = MOI.add_variable(model)
-#    end
-#    return model.z[key]
-#end
-#
-#function _homogenize(model::Optimizer, term::MOI.ScalarAffineTerm, vertex_or_edge)
-#    return MOI.ScalarAffineTerm(
-#        term.coefficient,
-#        _homogenize(model, term.variable, vertex_or_edge),
-#    )
-#end
 
 function _mult_subs(model, xterm::MOI.ScalarAffineTerm, ineq::MOI.ScalarAffineFunction)
     result = (xterm.coefficient * ineq.constant) * xterm.variable
@@ -95,17 +60,6 @@ end
 
 function _mult_subs(model, term::MOI.ScalarAffineTerm, ineq::MOI.VariableIndex)
     return term.coefficient * model.z[(term.variable, ineq)]
-end
-
-# Return the result of `affine * ineq` after substituting the bilinear terms `x * y` into `z`
-function _mult_subs(model::Optimizer, affine::MOI.ScalarAffineFunction{T}, ineq) where {T}
-    result = zero(MOI.ScalarAffineFunction{T})
-    for term in affine.terms
-        scalar = _mult_subs(model, term, ineq)
-        MOI.Utilities.operate!(+, T, result, scalar)
-    end
-    MOI.Utilities.operate!(+, T, result, affine.constant * ineq)
-    return result
 end
 
 function _mult_subs(model::Optimizer, affine::MOI.VectorAffineFunction{T}, ineq) where {T}
@@ -131,44 +85,64 @@ function _build_graph(graph::Graphs.DiGraph, src::MOI.ModelLike, ::Type{F}, ::Ty
     end
 end
 
+function _check(_, ci, _, ::MOI.VariableIndex, ::Nothing)
+    error("Constraint `$ci` is not assigned to any vertex or edge. You should set its `VertexOrEdge` attribute.")
+end
+
+function _check(model, ci, func, vi::MOI.VariableIndex, vertex::Int)
+    variable_vertex = model.variable_vertex[vi]
+    if variable_vertex != vertex
+        error("In constraint `$ci` of the vertex `$vertex`, the variable `$vi` of the function `$func` belongs to a different vertex `$variable_vertex`.")
+    end
+end
+
+function _check(model, ci, func, vi::MOI.VariableIndex, edge::Tuple{Int,Int})
+    variable_vertex = model.variable_vertex[vi]
+    if variable_vertex != edge[1] && variable_vertex != edge[2]
+        error("In constraint `$ci` of the edge `$edge`, the variable `$vi` of the function `$func` belongs to vertex `$variable_vertex` which is neither the source nor destination of the edge.")
+    end
+end
+
+function _check(model, ci, func::MOI.VectorAffineFunction, vertex_or_edge)
+    for term in func.terms
+        _check(model, ci, func, term.scalar_term.variable, vertex_or_edge)
+    end
+end
+
 # Function barrier to work around the type instability when getting `F` and `S`
-function _add_constraints(dest::Optimizer, src::MOI.ModelLike, ::Type{F}, ::Type{S}) where {F,S}
-    for ci in MOI.get(src, MOI.ListOfConstraintIndices{F,S}())
-        func = MOI.get(src, MOI.ConstraintFunction(), ci)
+function _add_constraints(dest::Optimizer, src::MOI.ModelLike, index_map, ::Type{F}, ::Type{S}) where {F,S}
+    cis = MOI.get(src, MOI.ListOfConstraintIndices{F,S}())
+    for ci in cis
+        func = MOI.Utilities.map_indices(index_map, MOI.get(src, MOI.ConstraintFunction(), ci))
         set = MOI.get(src, MOI.ConstraintSet(), ci)
-        @assert !(set isa MOI.Interval) # TODO exclude with `supports_constraint`
-        if MOI.Utilities.supports_shift_constant(typeof(set))
-            # We need to move the constant to the set to homogenize it
-            constant = MOI.constant(set)
-            func -= constant
-            set = MOI.Utilities.shift_constant(set, -constant)
-        end
         vertex_or_edge = MOI.get(src, VertexOrEdge(), ci)
+        _check(dest, ci, func, vertex_or_edge)
+        if vertex_or_edge isa Tuple{Int,Int}
+            vertex_or_edge = Graphs.Edge(vertex_or_edge...)
+        end
         # left of (5.8c) or (5.8e)
         linear = _mult_subs(dest, func, dest.y[vertex_or_edge])
-        _add_constraint(dest.inner, linear, set)
+        MOI.add_constraint(dest.inner, linear, set)
         if vertex_or_edge isa Int
             # It is a vertex so we can use Lemma 5.1 of the thesis
             # right of (5.8c)
             v = vertex_or_edge
             linear = _mult_subs(dest, func, 1.0 - dest.y[v])
-            _add_constraint(dest.inner, linear, set)
+            MOI.add_constraint(dest.inner, linear, set)
             # (5.8d)
             for u in Graphs.inneighbors(dest.graph, v)
-                linear = _mult_subs(dest, func, dest.y[(u, v)])
-                _add_constraint(dest.inner, linear, set)
+                linear = _mult_subs(dest, func, dest.y[Graphs.Edge(u, v)])
+                MOI.add_constraint(dest.inner, linear, set)
             end
             for u in Graphs.outneighbors(dest.graph, v)
-                linear = _mult_subs(dest, func, 1.0 - dest.y[(v, u)])
-                _add_constraint(dest.inner, linear, set)
+                linear = _mult_subs(dest, func, 1.0 - dest.y[Graphs.Edge(v, u)])
+                MOI.add_constraint(dest.inner, linear, set)
             end
         end
     end
+    filtered = MOI.Utilities.ModelFilter(filter_attributes, src)
+    MOI.Utilities.pass_attributes(dest.inner, filtered, index_map, cis)
 end
-
-# We need to put the constant back in the set when appropriate
-_add_constraint(model, f::MOI.AbstractScalarFunction, s) = MOI.Utilities.normalize_and_add_constraint(model, f, s)
-_add_constraint(model, f::MOI.AbstractVectorFunction, s) = MOI.add_constraint(model, f, s)
 
 struct ShortestPathProblem
     source::Int
@@ -180,22 +154,21 @@ MOI.Utilities.map_indices(::Function, p::ShortestPathProblem) = p
 function _constrain_admissible_subgraphs(model::Optimizer, spp::ShortestPathProblem)
     for v in Graphs.vertices(model.graph)
         y = model.y[v]
-        inv = MOI.VariableIndex[model.y[(u, v)] for u in Graphs.inneighbors(model.graph, v)]
+        inv = MOI.VariableIndex[model.y[Graphs.Edge(u, v)] for u in Graphs.inneighbors(model.graph, v)]
         MOI.add_constraint(
             model.inner,
             y - dot(ones(length(inv)), inv),
             MOI.EqualTo(float(v == spp.source)),
         )
-        outv = MOI.VariableIndex[model.y[(v, u)] for u in Graphs.outneighbors(model.graph, v)]
+        outv = MOI.VariableIndex[model.y[Graphs.Edge(v, u)] for u in Graphs.outneighbors(model.graph, v)]
         MOI.add_constraint(
             model.inner,
             y - dot(ones(length(outv)), outv),
             MOI.EqualTo(float(v == spp.target)),
         )
     end
-    for i in eachindex(model.x)
-        x = model.x[i]
-        v = model.variable_vertex[i]
+    for x in model.x
+        v = model.variable_vertex[x]
         z = model.z[(x, model.y[v])]
         inv = MOI.VariableIndex[model.z[(x, model.y[Graphs.Edge(u, v)])] for u in Graphs.inneighbors(model.graph, v)]
         MOI.add_constraint(
@@ -212,16 +185,21 @@ function _constrain_admissible_subgraphs(model::Optimizer, spp::ShortestPathProb
     end
 end
 
+filter_attributes(attr) = true
+filter_attributes(attr::VariableVertex) = false
+filter_attributes(attr::VertexOrEdge) = false
+filter_attributes(attr::Problem) = false
+
 function MOI.copy_to(dest::Optimizer, src::MOI.ModelLike)
     MOI.empty!(dest)
     vis = MOI.get(src, MOI.ListOfVariableIndices())
     dest.x = MOI.add_variables(dest.inner, length(vis))
     index_map = MOI.Utilities.IndexMap()
-    for i in eachindex(vis)
-        index_map[vis[i]] = dest.x[i]
+    for (vi, x) in zip(vis, dest.x)
+        index_map[vi] = x
+        dest.variable_vertex[x] = MOI.get.(src, VariableVertex(), vi)
     end
-    dest.variable_vertex = MOI.get.(src, VariableVertex(), vis)
-    vertices = unique!(sort(dest.variable_vertex))
+    vertices = unique!(sort(collect(values(dest.variable_vertex))))
     @assert vertices[1] == 1
     @assert vertices[end] == length(vertices)
     dest.graph = Graphs.DiGraph(length(vertices))
@@ -241,20 +219,40 @@ function MOI.copy_to(dest::Optimizer, src::MOI.ModelLike)
         dest.y[edge], _ = MOI.add_constrained_variable(dest.inner, MOI.ZeroOne())
     end
     # Create `z` variables
-    for i in eachindex(dest.x)
-        x = dest.x[i]
-        v = dest.variable_vertex[i]
+    for x in dest.x
+        v = dest.variable_vertex[x]
         dest.z[(x, dest.y[v])] = MOI.add_variable(dest.inner)
         for u in Graphs.inneighbors(dest.graph, v)
-            dest.z[(x, dest.y[Graphs.edge(u, v)])] = MOI.add_variable(dest.inner)
+            dest.z[(x, dest.y[Graphs.Edge(u, v)])] = MOI.add_variable(dest.inner)
         end
         for u in Graphs.outneighbors(dest.graph, v)
-            dest.z[(x, dest.y[Graphs.edge(v, u)])] = MOI.add_variable(dest.inner)
+            dest.z[(x, dest.y[Graphs.Edge(v, u)])] = MOI.add_variable(dest.inner)
         end
     end
+    filtered = MOI.Utilities.ModelFilter(filter_attributes, src)
+    MOI.Utilities.pass_attributes(dest.inner, filtered, index_map, vis)
+    MOI.Utilities.pass_attributes(dest.inner, filtered, index_map)
     for (F, S) in MOI.get(src, MOI.ListOfConstraintTypesPresent())
-        _add_constraints(dest, src, F, S)
+        _add_constraints(dest, src, index_map, F, S)
     end
     _constrain_admissible_subgraphs(dest, MOI.get(src, Problem()))
     return index_map
+end
+
+MOI.get(model::Optimizer, attr::MOI.AbstractModelAttribute) = MOI.get(model.inner, attr)
+MOI.get(model::Optimizer, attr::MOI.AbstractVariableAttribute, v) = MOI.get(model.inner, attr, v)
+
+struct SubGraph <: MOI.AbstractModelAttribute end
+MOI.is_set_by_optimize(::SubGraph) = true
+
+MOI.Utilities.map_indices(::MOI.Utilities.IndexMap, ::SubGraph, graph::Graphs.DiGraph) = graph
+
+function MOI.get(model::Optimizer, ::SubGraph)
+    graph = Graphs.DiGraph(Graphs.nv(model.graph))
+    for edge in Graphs.edges(model.graph)
+        if MOI.get(model.inner, MOI.VariablePrimal(), model.y[edge]) > 0.5
+            Graphs.add_edge!(graph, edge)
+        end
+    end
+    return graph
 end

--- a/src/bridges.jl
+++ b/src/bridges.jl
@@ -1,0 +1,13 @@
+function MOI.set(
+    model::MOI.ModelLike,
+    attr::VertexOrEdge,
+    bridge::MOI.Bridges.Constraint.VectorizeBridge,
+    value,
+)
+    return MOI.set(
+        model,
+        attr,
+        bridge.vector_constraint,
+        value,
+    )
+end


### PR DESCRIPTION
The examples now gives
<img width="600" height="400" alt="result" src="https://github.com/user-attachments/assets/74bd1509-a840-44e9-8b1d-d9aa6d0e8371" />
So it selects the path 1 -> 4 -> 2 which corresponds to s -> v2 -> t from the gcspy example.